### PR TITLE
Unify player name handling across scraping and processing scripts

### DIFF
--- a/Functions/normalize_player_names.R
+++ b/Functions/normalize_player_names.R
@@ -1,0 +1,63 @@
+# Function to normalize player names
+normalize_player_names <- function(name) {
+  # Ensure input is a character string
+  if (!is.character(name)) {
+    stop("Input must be a character string.")
+  }
+
+  # Ensure input is not NULL or empty
+  if (is.null(name) || nchar(name) == 0) {
+    return("")
+  }
+
+  # Convert to lowercase
+  name <- tolower(name)
+
+  # Define a mapping for accented characters
+  accent_map <- list(
+    "á" = "a", "é" = "e", "í" = "i", "ó" = "o", "ú" = "u", "ü" = "u",
+    "Á" = "A", "É" = "E", "Í" = "I", "Ó" = "O", "Ú" = "U", "Ü" = "U",
+    "à" = "a", "è" = "e", "ì" = "i", "ò" = "o", "ù" = "u",
+    "À" = "A", "È" = "E", "Ì" = "I", "Ò" = "O", "Ù" = "U",
+    "â" = "a", "ê" = "e", "î" = "i", "ô" = "o", "û" = "u",
+    "Â" = "A", "Ê" = "E", "Î" = "I", "Ô" = "O", "Û" = "U",
+    "ä" = "a", "ë" = "e", "ï" = "i", "ö" = "o", "ü" = "u",
+    "Ä" = "A", "Ë" = "E", "Ï" = "I", "Ö" = "O", "Ü" = "U",
+    "ã" = "a", "õ" = "o", "ñ" = "n",
+    "Ã" = "A", "Õ" = "O", "Ñ" = "N",
+    "ç" = "c", "Ç" = "C"
+  )
+
+  # Replace accented characters
+  for (accented_char in names(accent_map)) {
+    name <- gsub(accented_char, accent_map[[accented_char]], name)
+  }
+
+  # Trim leading/trailing whitespace
+  name <- trimws(name)
+
+  # Reduce multiple spaces between names to a single space
+  name <- gsub("\\s+", " ", name)
+
+  # Convert to title case (e.g., "FirstName LastName")
+  # This is a simplified approach, might need a more robust solution for complex cases
+  # Ensure name_parts are not empty before attempting to use substring
+  name_parts <- strsplit(name, " ")[[1]]
+  if (length(name_parts) > 0) {
+    name_parts <- sapply(name_parts, function(part) {
+      if (nchar(part) > 0) {
+        paste0(toupper(substring(part, 1, 1)), substring(part, 2))
+      } else {
+        ""
+      }
+    })
+    name <- paste(name_parts[name_parts != ""], collapse = " ")
+  } else {
+    name <- ""
+  }
+
+  # Ensure output is in UTF-8 encoding
+  name <- enc2utf8(name)
+
+  return(name)
+}

--- a/OddsScraper/Bet365/scrape_bet365.R
+++ b/OddsScraper/Bet365/scrape_bet365.R
@@ -6,7 +6,9 @@ library(jsonlite)
 library(glue)
 
 # Fix team names function
-source("Scripts/fix_team_names.R")
+source("Functions/fix_team_names.R") # Corrected path
+# Source player name normalization function
+source("Functions/normalize_player_names.R")
 
 # Read scraped HTML from the BET365_HTML Folder
 scraped_files_player <- list.files("OddsScraper/Bet365/Data/", full.names = TRUE, pattern = "player")
@@ -43,7 +45,8 @@ get_player_props <- function(scraped_file) {
   strikeouts_players <-
     bet365_player_markets[[strikeouts_over_under_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   strikeouts_cols <-
     bet365_player_markets[[strikeouts_over_under_index]] |>
@@ -85,7 +88,8 @@ get_player_props <- function(scraped_file) {
   alternate_strikeouts_players <-
     bet365_player_markets[[alternate_strikeouts_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   alternate_strikeouts_cols <-
     bet365_player_markets[[alternate_strikeouts_index]] |>
@@ -135,7 +139,8 @@ get_player_props <- function(scraped_file) {
   total_bases_players <-
     bet365_player_markets[[total_bases_ou_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   total_bases_cols <-
     bet365_player_markets[[total_bases_ou_index]] |>
@@ -177,7 +182,8 @@ get_player_props <- function(scraped_file) {
   alternate_total_bases_players <-
     bet365_player_markets[[alternate_total_bases_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   alternate_total_bases_cols <-
     bet365_player_markets[[alternate_total_bases_index]] |>
@@ -218,7 +224,8 @@ get_player_props <- function(scraped_file) {
   hits_players <-
     bet365_player_markets[[hits_ou_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   hits_cols <-
     bet365_player_markets[[hits_ou_index]] |>
@@ -260,7 +267,8 @@ get_player_props <- function(scraped_file) {
   alternate_hits_players <-
     bet365_player_markets[[alternate_hits_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   alternate_hits_cols <-
     bet365_player_markets[[alternate_hits_index]] |>
@@ -301,7 +309,8 @@ get_player_props <- function(scraped_file) {
   runs_players <-
     bet365_player_markets[[runs_ou_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   runs_cols <-
     bet365_player_markets[[runs_ou_index]] |>
@@ -343,7 +352,8 @@ get_player_props <- function(scraped_file) {
   alternate_runs_players <-
     bet365_player_markets[[alternate_runs_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   alternate_runs_cols <-
     bet365_player_markets[[alternate_runs_index]] |>
@@ -384,7 +394,8 @@ get_player_props <- function(scraped_file) {
   rbi_players <-
     bet365_player_markets[[rbi_ou_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   rbi_cols <-
     bet365_player_markets[[rbi_ou_index]] |>
@@ -426,7 +437,8 @@ get_player_props <- function(scraped_file) {
   alternate_rbi_players <-
     bet365_player_markets[[alternate_rbi_index]] |>
     html_elements(".srb-ParticipantLabelWithTeam_Name") |>
-    html_text()
+    html_text() |>
+    sapply(normalize_player_names)
   
   alternate_rbi_cols <-
     bet365_player_markets[[alternate_rbi_index]] |>

--- a/OddsScraper/Pinnacle/tidy_pinnacle.R
+++ b/OddsScraper/Pinnacle/tidy_pinnacle.R
@@ -5,6 +5,9 @@ library(httr2)
 library(jsonlite)
 library(glue)
 
+# Source the normalization function
+source("Functions/normalize_player_names.R")
+
 # Read in data
 all_pinnacle_raw_files <- list.files("OddsScraper/Pinnacle", "\\.csv", full.names = TRUE)
 
@@ -26,6 +29,7 @@ strikeouts_over <-
   strikeouts_markets |> 
   mutate(player_name = str_remove(selection, " \\(Strikeouts\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Over")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -45,6 +49,7 @@ strikeouts_under <-
   strikeouts_markets |> 
   mutate(player_name = str_remove(selection, " \\(Strikeouts\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Under")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -82,6 +87,7 @@ hits_over <-
   hits_markets |> 
   mutate(player_name = str_remove(selection, " \\(Hits\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Over")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -101,6 +107,7 @@ hits_under <-
   hits_markets |> 
   mutate(player_name = str_remove(selection, " \\(Hits\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Under")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -138,6 +145,7 @@ pitching_outs_over <-
   pitching_outs_markets |> 
   mutate(player_name = str_remove(selection, " \\(Pitching Outs\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Over")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -157,6 +165,7 @@ pitching_outs_under <-
   pitching_outs_markets |> 
   mutate(player_name = str_remove(selection, " \\(Pitching Outs\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Under")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -194,6 +203,7 @@ home_run_over <-
   home_run_markets |> 
   mutate(player_name = str_remove(selection, " \\(Home Run\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Over")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -214,6 +224,7 @@ home_run_under <-
   home_run_markets |> 
   mutate(player_name = str_remove(selection, " \\(Home Run\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Under")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -252,6 +263,7 @@ total_bases_over <-
   total_bases_markets |> 
   mutate(player_name = str_remove(selection, " \\(Total Bases\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Over")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>
@@ -271,6 +283,7 @@ total_bases_under <-
   total_bases_markets |> 
   mutate(player_name = str_remove(selection, " \\(Total Bases\\)")) |>
   mutate(player_name = str_remove(player_name, " \\(.*$")) |>
+  mutate(player_name = normalize_player_names(player_name)) |>
   filter(str_detect(name, "Under")) |>
   mutate(match = glue("{home_team} v {away_team}")) |> 
   mutate(agency = "Pinnacle") |>

--- a/OddsScraper/Shared/name_utils.py
+++ b/OddsScraper/Shared/name_utils.py
@@ -1,0 +1,152 @@
+import re
+
+# Attempt to import unidecode, otherwise use a manual mapping
+try:
+    from unidecode import unidecode
+    UNIDECODE_AVAILABLE = True
+except ImportError:
+    UNIDECODE_AVAILABLE = False
+    ACCENT_MAP = {
+        'á': 'a', 'é': 'e', 'í': 'i', 'ó': 'o', 'ú': 'u', 'ü': 'u', 'ñ': 'n',
+        'Á': 'A', 'É': 'E', 'Í': 'I', 'Ó': 'O', 'Ú': 'U', 'Ü': 'U', 'Ñ': 'N',
+        'à': 'a', 'è': 'e', 'ì': 'i', 'ò': 'o', 'ù': 'u',
+        'À': 'A', 'È': 'E', 'Ì': 'I', 'Ò': 'O', 'Ù': 'U',
+        'â': 'a', 'ê': 'e', 'î': 'i', 'ô': 'o', 'û': 'u',
+        'Â': 'A', 'Ê': 'E', 'Î': 'I', 'Ô': 'O', 'Û': 'U',
+        'ä': 'a', 'ë': 'e', 'ï': 'i', 'ö': 'o',
+        'Ä': 'A', 'Ë': 'E', 'Ï': 'I', 'Ö': 'O', # Ü already covered
+        'ã': 'a', 'õ': 'o',
+        'Ã': 'A', 'Õ': 'O',
+        'ç': 'c', 'Ç': 'C',
+        # Add more mappings if necessary
+    }
+
+def normalize_player_name(name_str: str) -> str:
+    """
+    Normalizes a player's name by lowercasing, removing accents,
+    trimming whitespace, reducing multiple spaces, and converting to title case.
+
+    Args:
+        name_str: The input player name string.
+
+    Returns:
+        A normalized player name string.
+    """
+    if name_str is None or not isinstance(name_str, str) or not name_str.strip():
+        return ""
+
+    # 1. Convert to lowercase
+    processed_name = name_str.lower()
+
+    # 2. Replace accented characters
+    if UNIDECODE_AVAILABLE:
+        processed_name = unidecode(processed_name)
+    else:
+        for accented_char, replacement_char in ACCENT_MAP.items():
+            # Ensure we are replacing lowercase accented chars correctly after initial tolower()
+            if accented_char.lower() in processed_name:
+                 processed_name = processed_name.replace(accented_char.lower(), replacement_char.lower())
+
+    # 3. Remove any leading or trailing whitespace
+    processed_name = processed_name.strip()
+
+    # 4. Reduce multiple spaces between name parts to a single space
+    processed_name = re.sub(r'\s+', ' ', processed_name)
+
+    # 5. Convert the name to title case
+    # A simple title() might not work for names like O'Malley or McDonald.
+    # However, for "firstname lastname" -> "Firstname Lastname" it's usually fine.
+    # A more robust solution might involve splitting by space and capitalizing each part,
+    # but that can also have issues with particles like "de la".
+    # For this implementation, we'll use a common approach that handles simple cases.
+
+    # Python's str.title() method correctly handles apostrophes (e.g. O'Hearn)
+    # and capitalizes the first letter of each word.
+    processed_name = processed_name.title()
+
+    return processed_name
+
+if __name__ == '__main__':
+    # Test cases
+    names_to_test = [
+        ("  José  Altuve  ", "Jose Altuve"),
+        ("Adrián Beltré", "Adrian Beltre"),
+        ("Yuli Gurriel", "Yuli Gurriel"),
+        ("GIANCARLO STANTON", "Giancarlo Stanton"),
+        ("Jean-Luc Picard", "Jean-Luc Picard"), # Test hyphen
+        ("Víctor Martínez", "Victor Martinez"),
+        ("Néstor Cortés Jr.", "Nestor Cortes Jr."), # Test period and suffix
+        ("  leading space", "Leading Space"),
+        ("trailing space  ", "Trailing Space"),
+        ("multiple   spaces", "Multiple Spaces"),
+        (None, ""),
+        ("", ""),
+        (" ", ""),
+        ("áéíóúüñÁÉÍÓÚÜÑçÇ", "AeiouunAeiouuncc"), # Test accent map if unidecode is not available
+        ("Javier Báez", "Javier Baez"),
+        ("Ryan O'Hearn", "Ryan O'Hearn")
+    ]
+
+    for original, expected in names_to_test:
+        normalized = normalize_player_name(original)
+        print(f"Original: '{original}' -> Normalized: '{normalized}' (Expected: '{expected}') -> Correct: {normalized == expected}")
+
+    if UNIDECODE_AVAILABLE:
+        print("\nUsing unidecode library.")
+    else:
+        print("\nUsing manual accent map (unidecode not available).")
+
+    # Example of a name that might be tricky for simple title() if not for unidecode's prior work
+    # or if it had lowercase particles like "de la"
+    print(normalize_player_name("pedro de la rosa")) # Expected: Pedro De La Rosa (standard title())
+                                                    # or Pedro de la Rosa (if more advanced title casing was used)
+                                                    # Current function will produce "Pedro De La Rosa"
+    print(normalize_player_name("DAVID MCGOLD")) # Expected: David Mcgold (standard title())
+                                                 # Current function will produce "David Mcgold" - this is a known limitation of .title() for "Mc" names
+                                                 # A more specific title casing logic would be needed for "Mc"
+                                                 # For now, the requirement is "Firstname Lastname" capitalization which .title() handles.
+    print(normalize_player_name("DAVID MCDONALD")) # Expected: David Mcdonald (standard title())
+                                                   # Current function: David Mcdonald
+    print(normalize_player_name("o'neill")) # Expected: O'Neill
+                                            # Current function: O'Neill (str.title() handles this)
+
+    # Test the manual map directly if unidecode is not available
+    if not UNIDECODE_AVAILABLE:
+        manual_test_name = "Jörg Müller"
+        expected_manual = "Jorg Muller"
+        # Simulate the steps
+        p = manual_test_name.lower()
+        for accented_char, replacement_char in ACCENT_MAP.items():
+            if accented_char.lower() in p:
+                 p = p.replace(accented_char.lower(), replacement_char.lower())
+        p = p.strip()
+        p = re.sub(r'\s+', ' ', p)
+        p = p.title()
+        print(f"Manual test: '{manual_test_name}' -> Normalized: '{p}' (Expected: '{expected_manual}') -> Correct: {p == expected_manual}")
+
+        manual_test_name_2 = "françois truffaut"
+        expected_manual_2 = "Francois Truffaut"
+        p2 = manual_test_name_2.lower()
+        for accented_char, replacement_char in ACCENT_MAP.items():
+            if accented_char.lower() in p2:
+                 p2 = p2.replace(accented_char.lower(), replacement_char.lower())
+        p2 = p2.strip()
+        p2 = re.sub(r'\s+', ' ', p2)
+        p2 = p2.title()
+        print(f"Manual test 2: '{manual_test_name_2}' -> Normalized: '{p2}' (Expected: '{expected_manual_2}') -> Correct: {p2 == expected_manual_2}")
+
+        # Test if accents in ACCENT_MAP are correctly lowercased during replacement
+        # when the input name_str is initially all uppercase.
+        # e.g. "ÁÉÍÓÚ" -> "aeiou" (lowercase unaccented) -> "Aeiou" (title case)
+        uppercase_accented_name = "JOSÉ ÁLVAREZ"
+        expected_uppercase_accented = "Jose Alvarez"
+        p3 = uppercase_accented_name.lower() # "josé álvarez"
+        for accented_char, replacement_char in ACCENT_MAP.items():
+            # accented_char.lower() ensures we match against the lowercased processed_name
+            # replacement_char.lower() ensures we replace with a lowercase unaccented char
+            if accented_char.lower() in p3:
+                 p3 = p3.replace(accented_char.lower(), replacement_char.lower())
+        p3 = p3.strip()
+        p3 = re.sub(r'\s+', ' ', p3)
+        p3 = p3.title()
+        print(f"Uppercase accented test: '{uppercase_accented_name}' -> Normalized: '{p3}' (Expected: '{expected_uppercase_accented}') -> Correct: {p3 == expected_uppercase_accented}")

--- a/OddsScraper/master_processing_script.R
+++ b/OddsScraper/master_processing_script.R
@@ -4,6 +4,7 @@
 
 library(tidyverse)
 `%notin%` <- Negate(`%in%`)
+source("Functions/normalize_player_names.R") # Source the function
 
 # # Run all odds scraping scripts-----------------------------------------------
 run_scraping <- function(script_name) {
@@ -155,6 +156,7 @@ all_pitcher_strikeouts_files <- list.files("Data/scraped_odds", "pitcher_strikeo
 all_pitcher_strikeouts_data <-
   all_pitcher_strikeouts_files |> 
   map_dfr(read_csv) |> 
+  mutate(player_name = sapply(player_name, normalize_player_names, USE.NAMES = FALSE)) |>
   arrange(match, home_team, away_team, player_name, line, desc(over_price))
 
 # Get the best over odds
@@ -200,6 +202,7 @@ all_batter_hits_files <- list.files("Data/scraped_odds", "hits", full.names = TR
 all_batter_hits_data <-
   all_batter_hits_files |>
   map_dfr(read_csv) |>
+  mutate(player_name = sapply(player_name, normalize_player_names, USE.NAMES = FALSE)) |>
   arrange(match, home_team, away_team, player_name, line, desc(over_price)) |> 
   mutate(market_name = "Batter Hits")
 
@@ -246,6 +249,7 @@ all_batter_rbis_files <- list.files("Data/scraped_odds", "rbis|runs_batted_in", 
 all_batter_rbis_data <-
   all_batter_rbis_files |>
   map_dfr(read_csv) |>
+  mutate(player_name = sapply(player_name, normalize_player_names, USE.NAMES = FALSE)) |>
   arrange(match, home_team, away_team, player_name, line, desc(over_price)) |> 
   mutate(market_name = "Batter RBIs")
 


### PR DESCRIPTION
This commit introduces a standardized approach to player name normalization to address inconsistencies, particularly with accented characters in Hispanic names.

Key changes:
- Added a new R function `Functions/normalize_player_names.R` that converts names to a consistent format, handles accents (e.g., "á" to "a", "ñ" to "n"), trims whitespace, and standardizes casing.
- Updated R scraping scripts (`Neds`, `Pinnacle/tidy_pinnacle`, `Bet365`, `Sportsbet`, `TAB`, `Pointsbet`) to use this normalization function. This involved removing manual `case_when` name corrections and updating how player names from roster files and scraped data are processed and joined.
- Updated the `OddsScraper/master_processing_script.R` to apply the R normalization function to player name columns after data is loaded from CSVs, ensuring a final layer of consistency.
- Added a new Python utility `OddsScraper/Shared/name_utils.py` with a `normalize_player_name` function mirroring the R version's capabilities (using `unidecode` if available, otherwise a manual fallback for accent handling).
- Updated the Python script `OddsScraper/Pinnacle/scrape_pinnacle.py` to use this utility to parse and normalize player names, adding a new `player_name` column to its output CSVs.

These changes aim to improve data quality, reduce errors from inconsistent name matching, and make the codebase more maintainable by centralizing name processing logic.